### PR TITLE
Log Analytics Workspace

### DIFF
--- a/idem_provider_azurerm/exec/azurerm/authorization/role.py
+++ b/idem_provider_azurerm/exec/azurerm/authorization/role.py
@@ -45,6 +45,7 @@ to every function in order to work properly.
       * ``AZURE_GERMAN_CLOUD``
 
 '''
+
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -62,114 +63,13 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-async def definitions_create_or_update(hub, defintion_id, scope, role_name=None, description=None, role_type=None,
-                                       permissions=None, assignable_scopes=None, **kwargs):
-    '''
-    .. versionadded:: VERSION
-
-    Creates or updates a role definition.
-
-    :param definition_id: The ID of the role definiton.
-
-    :param scope: The scope of the role definition.
-
-    :param role_name: The role name.
-
-    :param description: The role definition description.
-
-    :param role_type: The role type.
-
-    :param permissions: A list of dictionaries representing role definition Permission objects. Valid parameters are:
-        - ``actions``: A list of strings representing allowed actions.
-        - ``not_actions``: A list of strings representing denied actions.
-
-    :param assignable_scopes: A list of role definition assignable scopes.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        azurerm.authorization.role.definitions_create_or_update test_defintion_id test_scope
-
-    '''
-    result = {}
-    authconn = await hub.exec.utils.azurerm.get_client('authorization', **kwargs)
-
-    try:
-        defmodel = await hub.exec.utils.azurerm.create_object_model(
-            'authorization',
-            'RoleDefinition',
-            role_name=role_name,
-            description=description,
-            role_type=role_type,
-            permissions=permissions,
-            assignable_scopes=assignable_scopes,
-            **kwargs
-        )
-
-    except TypeError as exc:
-        result = {'error': 'The object model could not be built. ({0})'.format(str(exc))}
-        return result
-
-    try:
-        role = authconn.role_definitions.create(
-            role_definition_id=definition_id,
-            scope=scope,
-            role_definition=defmodel
-        )
-
-        result = role.as_dict()
-    except CloudError as exc:
-        await hub.exec.utils.azurerm.log_cloud_error('authorization', str(exc), **kwargs)
-        result = {'error': str(exc)}
-    except SerializationError as exc:
-        result = {'error': 'The object model could not be parsed. ({0})'.format(str(exc))}
-
-    return result
-
-
-async def definitions_delete(hub, definition_id, scope, **kwargs):
-    '''
-    .. versionadded:: VERSION
-
-    Deletes a role definition.
-
-    :param definition_id: The ID of the role definition to delete.
-
-    :param scope: The scope of the role definition.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        azurerm.authorization.role.definitions_delete test_name test_scope
-
-    '''
-    result = False
-    authconn = await hub.exec.utils.azurerm.get_client('authorization', **kwargs)
-
-    try:
-
-    role = authconn.role_definitions.delete(
-        role_definition_id=definition_id,
-        **kwargs
-    )
-
-    result = True
-    except CloudError as exc:
-        await hub.exec.utils.azurerm.log_cloud_error('authorization', str(exc), **kwargs)
-        result = {'error': str(exc)}
-
-    return result
-
-
-async def definitions_get(hub, definition_id, scope, **kwargs):
+async def definitions_get(hub, role_id, scope, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
     Get role definition by name (GUID).
 
-    :param definition_id: The ID of the role definition.
+    :param role_id: The ID of the role definition.
 
     :param scope: The scope of the role definition.
 
@@ -177,7 +77,7 @@ async def definitions_get(hub, definition_id, scope, **kwargs):
 
     .. code-block:: bash
 
-        azurerm.authorization.role.definitions_get test_id test_scope
+        azurerm.authorization.role.definitions_get testid testscope
 
     '''
     result = {}
@@ -186,7 +86,7 @@ async def definitions_get(hub, definition_id, scope, **kwargs):
     try:
         defs = authconn.role_definitions.get(
             scope=scope,
-            role_definition_id=definition_id,
+            role_definition_id=role_id,
             **kwargs
         )
 
@@ -198,7 +98,7 @@ async def definitions_get(hub, definition_id, scope, **kwargs):
     return result
 
 
-async def definitions_get_by_id(hub, definition_id, **kwargs):
+async def definitions_get_by_id(hub, role_id, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -213,7 +113,7 @@ async def definitions_get_by_id(hub, definition_id, **kwargs):
 
     .. code-block:: bash
 
-        azurerm.authorization.role.definitions_get_by_id test_id
+        azurerm.authorization.role.definitions_get_by_id testid
 
     '''
     result = {}
@@ -221,7 +121,7 @@ async def definitions_get_by_id(hub, definition_id, **kwargs):
 
     try:
         defs = authconn.role_definitions.get_by_id(
-            role_definition_id=definition_id,
+            role_definition_id=role_id,
             **kwargs
         )
 
@@ -245,7 +145,7 @@ async def definitions_list(hub, scope, **kwargs):
 
     .. code-block:: bash
 
-        azurerm.authorization.role.definitions_list test_scope
+        azurerm.authorization.role.definitions_list testscope
 
     '''
     result = {}
@@ -268,186 +168,6 @@ async def definitions_list(hub, scope, **kwargs):
     return result
 
 
-async def assignments_create(hub, name, scope, definition_id, principal_id, **kwargs):
-    '''
-    .. versionadded:: VERSION
-
-    Creates a role assignment.
-
-    :param name: The name of the role assignment to create. It can be any valid GUID.
-
-    :param scope: The scope of the role assignment to create. The scope can be any REST resource instance.
-        For example, use '/subscriptions/{subscription-id}/' for a subscription,
-        '/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}' for a resource group, and
-        '/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/providers/{resource-provider}/{resource-type}/{resource-name}'
-        for a resource.
-
-    :param definition_id: The role definition ID used in the role assignment.
-
-    :param principal_id: The principal ID assigned to the role. This maps to the ID inside the Active Directory.
-        It can point to a user, service principal, or security group.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        azurerm.authorization.role.assignments_create test_name test_scope test_def test_principal
-
-    '''
-    result = {}
-    authconn = await hub.exec.utils.azurerm.get_client('authorization', **kwargs)
-
-    try:
-        rolemodel = await hub.exec.utils.azurerm.create_object_model(
-            'authorization',
-            'RoleAssignmentProperties',
-            role_definition_id=definition_id,
-            principal_id=principal_id,
-            **kwargs
-        )
-    except TypeError as exc:
-        result = {'error': 'The object model could not be built. ({0})'.format(str(exc))}
-        return result
-
-    try:
-        role = authconn.role_assignments.create(
-            role_assignment_name=name,
-            scope=scope,
-            properties=rolemodel
-        )
-
-        result = role.as_dict()
-    except CloudError as exc:
-        await hub.exec.utils.azurerm.log_cloud_error('authorization', str(exc), **kwargs)
-        result = {'error': str(exc)}
-    except SerializationError as exc:
-        result = {'error': 'The object model could not be parsed. ({0})'.format(str(exc))}
-
-    return result
-
-
-async def assignments_create_by_id(hub, assignment_id, definition_id, principal_id, **kwargs):
-    '''
-    .. versionadded:: VERSION
-
-    Creates a role assignment by ID.
-
-    :param assignment_id: The fully qualified ID of the role assignment, including the scope, resource name and resource
-        type. Use the format, /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}.
-        Example: /subscriptions/{subId}/resourcegroups/{rgname}//providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}.
-
-    :param definition_id: The role definition ID used in the role assignment.
-
-    :param principal_id: The principal ID assigned to the role. This maps to the ID inside the Active Directory.
-        It can point to a user, service principal, or security group.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        azurerm.authorization.role.assignments_create_by_id test_id test_def test_principal
-
-    '''
-    result = {}
-    authconn = await hub.exec.utils.azurerm.get_client('authorization', **kwargs)
-
-    try:
-        rolemodel = await hub.exec.utils.azurerm.create_object_model(
-            'authorization',
-            'RoleAssignmentProperties',
-            role_definition_id=definition_id,
-            principal_id=principal_id,
-            **kwargs
-        )
-    except TypeError as exc:
-        result = {'error': 'The object model could not be built. ({0})'.format(str(exc))}
-        return result
-
-    try:
-        role = authconn.role_assignments.create(
-            role_assignment_id=assignment_id,
-            properties=rolemodel
-        )
-
-        result = role.as_dict()
-    except CloudError as exc:
-        await hub.exec.utils.azurerm.log_cloud_error('authorization', str(exc), **kwargs)
-        result = {'error': str(exc)}
-    except SerializationError as exc:
-        result = {'error': 'The object model could not be parsed. ({0})'.format(str(exc))}
-
-    return result
-
-
-async def assignments_delete(hub, name, scope, **kwargs):
-    '''
-    .. versionadded:: VERSION
-
-    Deletes a role assignment.
-
-    :param name: The name of the lock to be deleted.
-
-    :param scope: The scope of the role assignment to delete.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        azurerm.authorization.role.assignments_delete test_name test_scope
-
-    '''
-    result = False
-    authconn = await hub.exec.utils.azurerm.get_client('authorization', **kwargs)
-
-    try:
-        role = authconn.role_assignments.delete(
-            role_assignment_name=name,
-            scope=scope,
-            **kwargs
-        )
-
-        result = True
-    except CloudError as exc:
-        await hub.exec.utils.azurerm.log_cloud_error('authorization', str(exc), **kwargs)
-        result = {'error': str(exc)}
-
-    return result
-
-
-async def assignments_delete_by_id(hub, assignment_id, **kwargs):
-    '''
-    .. versionadded:: VERSION
-
-    Deletes a role assignment by ID.
-
-    :param assignment_id: The fully qualified ID of the role assignment, including the scope, resource name and resource
-        type. Use the format, /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}.
-        Example: /subscriptions/{subId}/resourcegroups/{rgname}//providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        azurerm.authorization.role.assignments_delete_by_id test_id
-
-    '''
-    result = False
-    authconn = await hub.exec.utils.azurerm.get_client('authorization', **kwargs)
-
-    try:
-        role = authconn.role_assignments.delete_by_id(
-            role_assignment_id=assignment_id,
-            **kwargs
-        )
-
-        result = True
-    except CloudError as exc:
-        await hub.exec.utils.azurerm.log_cloud_error('authorization', str(exc), **kwargs)
-        result = {'error': str(exc)}
-
-    return result
-
-
 async def assignments_get(hub, name, scope, **kwargs):
     '''
     .. versionadded:: 1.0.0
@@ -462,7 +182,7 @@ async def assignments_get(hub, name, scope, **kwargs):
 
     .. code-block:: bash
 
-        azurerm.authorization.role.assignments_get test_name test_scope
+        azurerm.authorization.role.assignments_get testname testscope
 
     '''
     result = {}
@@ -497,7 +217,7 @@ async def assignments_get_by_id(hub, assignment_id, **kwargs):
 
     .. code-block:: bash
 
-        azurerm.authorization.role.assignments_get_by_id test_id
+        azurerm.authorization.role.assignments_get_by_id testid
 
     '''
     result = {}
@@ -570,8 +290,8 @@ async def assignments_list_for_resource(hub, name, resource_group, resource_prov
 
     .. code-block:: bash
 
-        azurerm.authorization.role.assignments_list_for_resource test_name test_group test_namespace \
-                  test_type test_path
+        azurerm.authorization.role.assignments_list_for_resource testname testgroup testnamespace \
+                  testtype testpath
 
     '''
     result = {}
@@ -613,7 +333,7 @@ async def assignments_list_for_resource_group(hub, name, **kwargs):
 
     .. code-block:: bash
 
-        azurerm.authorization.role.assignments_list_for_resource_group test_group
+        azurerm.authorization.role.assignments_list_for_resource_group testgroup
 
     '''
     result = {}
@@ -648,7 +368,7 @@ async def assignments_list_for_scope(hub, scope, **kwargs):
 
     .. code-block:: bash
 
-        azurerm.authorization.role.assignments_list_for_scope test_scope
+        azurerm.authorization.role.assignments_list_for_scope testscope
 
     '''
     result = {}

--- a/idem_provider_azurerm/exec/azurerm/log_analytics/workspace.py
+++ b/idem_provider_azurerm/exec/azurerm/log_analytics/workspace.py
@@ -2,7 +2,7 @@
 '''
 Azure Resource Manager (ARM) Log Analytics Workspace Execution Module
 
-.. versionadded:: 1.0.0
+.. versionadded:: VERSION
 
 :maintainer: <devops@eitr.tech>
 :maturity: new
@@ -59,11 +59,12 @@ try:
 except ImportError:
     pass
 
+__func_alias__ = {"list_": "list"}
+
 log = logging.getLogger(__name__)
 
 
-async def create_or_update(hub, name, resource_group, location, sku=None, retention=None, customer_id=None, etag=None,
-                           **kwargs):
+async def create_or_update(hub, name, resource_group, location, sku=None, retention=None, customer_id=None, **kwargs):
     '''
     .. versionadded:: VERSION
 
@@ -83,8 +84,6 @@ async def create_or_update(hub, name, resource_group, location, sku=None, retent
 
     :param customer_id: The ID associated with the workspace. Setting this value at creation time allows the workspace
         being created to be linked to an existing workspace.
-
-    :param etag: The ETag of the workspace.
 
     CLI Example:
 
@@ -107,7 +106,6 @@ async def create_or_update(hub, name, resource_group, location, sku=None, retent
             sku=sku,
             customer_id=customer_id,
             retention=retention,
-            e_tag=etag,
             **kwargs
         )
 
@@ -204,13 +202,13 @@ async def list_(hub, **kwargs):
     .. versionadded:: VERSION
 
     Gets the workspaces in a subscription.
-    
+
     CLI Example:
-    
+
     .. code-block:: bash
-    
+
         azurerm.log_analytics.workspace.list
-    
+
     '''
     result = {}
     logconn = await hub.exec.utils.azurerm.get_client('loganalytics', **kwargs)
@@ -233,10 +231,10 @@ async def list_by_resource_group(hub, resource_group, **kwargs):
     '''
     .. versionadded:: VERSION
 
-    Gets the workspaces in a resource group.  
-                                           
+    Gets the workspaces in a resource group.
+
     :param resource_group: The name of the resource group to get. The name is case insensitive.
-                                                  
+
     CLI Example:
 
     .. code-block:: bash

--- a/idem_provider_azurerm/exec/azurerm/log_analytics/workspace.py
+++ b/idem_provider_azurerm/exec/azurerm/log_analytics/workspace.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+'''
+Azure Resource Manager (ARM) Log Analytics Workspace Execution Module
+
+.. versionadded:: 1.0.0
+
+:maintainer: <devops@eitr.tech>
+:maturity: new
+:depends:
+    * `azure <https://pypi.python.org/pypi/azure>`_ >= 4.0.0
+    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.23
+    * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 4.0.0
+    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 4.6.2
+    * `azure-mgmt-loganalytics <https://pypi.org/project/azure-mgmt-loganalytics/>`_ >= 0.2.0
+    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 4.0.0
+    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 2.2.0
+    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 2.0.0
+    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.35.0
+    * `azure-storage <https://pypi.python.org/pypi/azure-storage>`_ >= 0.36.0
+    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.1
+:platform: linux
+
+:configuration: This module requires Azure Resource Manager credentials to be passed as keyword arguments
+    to every function in order to work properly.
+
+    Required provider parameters:
+
+    if using username and password:
+      * ``subscription_id``
+      * ``username``
+      * ``password``
+
+    if using a service principal:
+      * ``subscription_id``
+      * ``tenant``
+      * ``client_id``
+      * ``secret``
+
+    Optional provider parameters:
+
+**cloud_environment**: Used to point the cloud driver to different API endpoints, such as Azure GovCloud.
+    Possible values:
+      * ``AZURE_PUBLIC_CLOUD`` (default)
+      * ``AZURE_CHINA_CLOUD``
+      * ``AZURE_US_GOV_CLOUD``
+      * ``AZURE_GERMAN_CLOUD``
+
+'''
+# Python libs
+from __future__ import absolute_import
+import logging
+
+# Azure libs
+HAS_LIBS = False
+try:
+    from msrest.exceptions import SerializationError
+    from msrestazure.azure_exceptions import CloudError
+    HAS_LIBS = True
+except ImportError:
+    pass
+
+log = logging.getLogger(__name__)
+
+
+async def create_or_update(hub, name, resource_group, location, sku=None, retention=None, customer_id=None, etag=None,
+                           **kwargs):
+    '''
+    .. versionadded:: VERSION
+
+    Create or update a workspace.
+
+    :param name: The name of the workspace.
+
+    :param resource_group: The resource group name of the workspace.
+
+    :param location: The resource location.
+
+    :param sku: The name of the SKU. Possible values include: 'Free', 'Standard', 'Premium', 'Unlimited', 'PerNode',
+        'PerGB2018', 'Standalone'.
+
+    :param retention: The workspace data retention in days. -1 means Unlimited retention for the Unlimited Sku.
+        730 days is the maximum allowed for all other Skus.
+
+    :param customer_id: The ID associated with the workspace. Setting this value at creation time allows the workspace
+        being created to be linked to an existing workspace.
+
+    :param etag: The ETag of the workspace.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        azurerm.log_analytics.workspace.create test_name test_group test_location
+
+    '''
+    result = {}
+    logconn = await hub.exec.utils.azurerm.get_client('loganalytics', **kwargs)
+
+    if sku:
+        sku = {'name': sku}
+
+    try:
+        spacemodel = await hub.exec.utils.azurerm.create_object_model(
+            'loganalytics',
+            'Workspace',
+            location=location,
+            sku=sku,
+            customer_id=customer_id,
+            retention_in_days=retention,
+            e_tag=etag,
+            **kwargs
+        )
+
+    except TypeError as exc:
+        result = {'error': 'The object model could not be built. ({0})'.format(str(exc))}
+        return result
+
+    try:
+        workspace = logconn.workspaces.create_or_update(
+            role_assignment_name=name,
+            workspace_name=name,
+            resource_group_name=resource_group,
+            parameters=spacemodel
+        )
+
+        result = workspace.result().as_dict()
+    except CloudError as exc:
+        await hub.exec.utils.azurerm.log_cloud_error('loganalytics', str(exc), **kwargs)
+        result = {'error': str(exc)}
+    except SerializationError as exc:
+        result = {'error': 'The object model could not be parsed. ({0})'.format(str(exc))}
+
+    return result
+
+
+async def delete(hub, name, resource_group, **kwargs):
+    '''
+    .. versionadded:: VERSION
+
+    Deletes a workspace instance.
+
+    :param name: The name of the workspace.
+
+    :param resource_group: The resource group name of the workspace.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        azurerm.log_analytics.workspace.delete test_name test_group
+
+    '''
+    result = False
+    logconn = await hub.exec.utils.azurerm.get_client('loganalytics', **kwargs)
+
+    try:
+        workspace = logconn.workspaces.delete(
+            workspace_name=name,
+            resource_group_name=resource_group
+        )
+
+        result = True
+    except CloudError as exc:
+        await hub.exec.utils.azurerm.log_cloud_error('loganalytics', str(exc), **kwargs)
+
+    return result
+
+
+async def get(hub, name, resource_group, **kwargs):
+    '''
+    .. versionadded:: VERSION
+
+    Gets a workspace instance.
+
+    :param name: The name of the workspace.
+
+    :param resource_group: The resource group name of the workspace.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        azurerm.log_analytics.workspace.get test_name test_group
+
+    '''
+    result = {}
+    logconn = await hub.exec.utils.azurerm.get_client('loganalytics', **kwargs)
+
+    try:
+        workspace = logconn.workspaces.get(
+            workspace_name=name,
+            resource_group_name=resource_group
+        )
+
+        result = workspace.as_dict()
+    except CloudError as exc:
+        await hub.exec.utils.azurerm.log_cloud_error('loganalytics', str(exc), **kwargs)
+        result = {'error': str(exc)}
+
+    return result
+
+
+async def list_(hub, **kwargs):
+    '''
+    .. versionadded:: VERSION
+
+    Gets the workspaces in a subscription.
+    
+    CLI Example:
+    
+    .. code-block:: bash
+    
+        azurerm.log_analytics.workspace.list
+    
+    '''
+    result = {}
+    logconn = await hub.exec.utils.azurerm.get_client('loganalytics', **kwargs)
+
+    try:
+        workspaces = await hub.exec.utils.azurerm.paged_object_to_list(
+            logconn.workspaces.list()
+        )
+
+        for workspace in workspaces:
+            result[workspace['name']] = workspace
+    except CloudError as exc:
+        await hub.exec.utils.azurerm.log_cloud_error('loganalytics', str(exc), **kwargs)
+        result = {'error': str(exc)}
+
+    return result
+
+
+async def list_by_resource_group(hub, resource_group, **kwargs):
+    '''
+    .. versionadded:: VERSION
+
+    Gets the workspaces in a resource group.  
+                                           
+    :param resource_group: The name of the resource group to get. The name is case insensitive.
+                                                  
+    CLI Example:
+
+    .. code-block:: bash
+
+        azurerm.log_analytics.workspace.list_by_resource_group test_group
+
+    '''
+    result = {}
+    logconn = await hub.exec.utils.azurerm.get_client('loganalytics', **kwargs)
+
+    try:
+        workspaces = await hub.exec.utils.azurerm.paged_object_to_list(
+            logconn.workspaces.list_by_resource_group(
+                resource_group_name=resource_group
+            )
+        )
+
+        for workspace in workspaces:
+            result[workspace['name']] = workspace
+    except CloudError as exc:
+        await hub.exec.utils.azurerm.log_cloud_error('loganalytics', str(exc), **kwargs)
+        result = {'error': str(exc)}
+
+    return result
+
+
+async def list_intelligence_packs(hub, name, resource_group, **kwargs):
+    '''
+    .. versionadded:: VERSION
+
+    Lists all the intelligence packs possible and whether they are enabled or disabled for a given workspace.
+
+    :param name: Name of the workspace.
+
+    :param resource_group: The resource group name of the workspace.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        azurerm.log_analytics.workspace.list_intelligence_packs test_name test_group
+
+    '''
+    result = {}
+    logconn = await hub.exec.utils.azurerm.get_client('loganalytics', **kwargs)
+
+    try:
+        packs = logconn.workspaces.list_intelligence_packs(
+            workspace_name=name,
+            resource_group_name=resource_group
+        )
+
+        for pack in packs:
+            pack = pack.as_dict()
+            result[pack['name']] = pack
+    except CloudError as exc:
+        await hub.exec.utils.azurerm.log_cloud_error('loganalytics', str(exc), **kwargs)
+        result = {'error': str(exc)}
+
+    return result

--- a/idem_provider_azurerm/exec/azurerm/log_analytics/workspace.py
+++ b/idem_provider_azurerm/exec/azurerm/log_analytics/workspace.py
@@ -106,7 +106,7 @@ async def create_or_update(hub, name, resource_group, location, sku=None, retent
             location=location,
             sku=sku,
             customer_id=customer_id,
-            retention_in_days=retention,
+            retention=retention,
             e_tag=etag,
             **kwargs
         )
@@ -117,7 +117,6 @@ async def create_or_update(hub, name, resource_group, location, sku=None, retent
 
     try:
         workspace = logconn.workspaces.create_or_update(
-            role_assignment_name=name,
             workspace_name=name,
             resource_group_name=resource_group,
             parameters=spacemodel

--- a/idem_provider_azurerm/exec/utils/azurerm.py
+++ b/idem_provider_azurerm/exec/utils/azurerm.py
@@ -144,7 +144,8 @@ async def get_client(hub, client_type, **kwargs):
                   'subscription': 'Subscription',
                   'web': 'WebSiteManagement',
                   'keyvault': 'KeyVaultManagement',
-                  'redis': 'RedisManagement'}
+                  'redis': 'RedisManagement',
+                  'loganalytics': 'LogAnalyticsManagement'}
 
     if client_type not in client_map:
         raise Exception(

--- a/idem_provider_azurerm/states/azurerm/log_analytics/workspace.py
+++ b/idem_provider_azurerm/states/azurerm/log_analytics/workspace.py
@@ -72,7 +72,7 @@ log = logging.getLogger(__name__)
 TREQ = {
     'present': {
         'require': [
-            'azurerm.resource.group.present',
+            'states.azurerm.resource.group.present',
         ]
     }
 }

--- a/idem_provider_azurerm/states/azurerm/log_analytics/workspace.py
+++ b/idem_provider_azurerm/states/azurerm/log_analytics/workspace.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+'''
+Azure Resource Manager (ARM) Log Analytics Workspace State Module
+
+.. versionadded:: 1.0.0
+
+:maintainer: <devops@eitr.tech>
+:maturity: new
+:depends:
+    * `azure <https://pypi.python.org/pypi/azure>`_ >= 4.0.0
+    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.23
+    * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 4.0.0
+    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 4.6.2
+    * `azure-mgmt-loganalytics <https://pypi.org/project/azure-mgmt-loganalytics/>`_ >= 0.2.0
+    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 4.0.0
+    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 2.2.0
+    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 2.0.0
+    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.35.0
+    * `azure-storage <https://pypi.python.org/pypi/azure-storage>`_ >= 0.36.0
+    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.1
+:platform: linux
+
+:configuration: This module requires Azure Resource Manager credentials to be passed as a dictionary of
+    keyword arguments to the ``connection_auth`` parameter in order to work properly. Since the authentication
+    parameters are sensitive, it's recommended to pass them to the states via pillar.
+
+    Required provider parameters:
+
+    if using username and password:
+      * ``subscription_id``
+      * ``username``
+      * ``password``
+
+    if using a service principal:
+      * ``subscription_id``
+      * ``tenant``
+      * ``client_id``
+      * ``secret``
+
+    Optional provider parameters:
+
+    **cloud_environment**: Used to point the cloud driver to different API endpoints, such as Azure GovCloud. Possible values:
+      * ``AZURE_PUBLIC_CLOUD`` (default)
+      * ``AZURE_CHINA_CLOUD``
+      * ``AZURE_US_GOV_CLOUD``
+      * ``AZURE_GERMAN_CLOUD``
+
+    Example Pillar for Azure Resource Manager authentication:
+
+    .. code-block:: yaml
+
+        azurerm:
+            user_pass_auth:
+                subscription_id: 3287abc8-f98a-c678-3bde-326766fd3617
+                username: fletch
+                password: 123pass
+            mysubscription:
+                subscription_id: 3287abc8-f98a-c678-3bde-326766fd3617
+                tenant: ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF
+                client_id: ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF
+                secret: XXXXXXXXXXXXXXXXXXXXXXXX
+                cloud_environment: AZURE_PUBLIC_CLOUD
+
+'''
+# Python libs
+from __future__ import absolute_import
+import logging
+from operator import itemgetter
+
+log = logging.getLogger(__name__)
+
+TREQ = {
+    'present': {
+        'require': [
+            'azurerm.resource.group.present',
+        ]
+    }
+}
+
+
+async def present(hub, ctx, name, resource_group, location, sku=None, retention=None, customer_id=None, etag=None,
+                  tags=None, connection_auth=None, **kwargs):
+    '''
+    .. versionadded:: VERSION
+
+    Ensure a specified log analytics workspace exists.
+
+    :param name: The name of the workspace.
+
+    :param resource_group: The resource group name of the workspace.
+
+    :param location: The resource location.
+
+    :param sku: The name of the SKU. Possible values include: 'Free', 'Standard', 'Premium', 'Unlimited', 'PerNode',
+        'PerGB2018', 'Standalone'.
+
+    :param retention: The workspace data retention in days. -1 means Unlimited retention for the Unlimited Sku.
+        730 days is the maximum allowed for all other Skus.
+
+    :param customer_id: The ID associated with the workspace. Setting this value at creation time allows the workspace
+        being created to be linked to an existing workspace.
+
+    :param etag: The ETag of the workspace.
+
+    :param tags: A dictionary of strings can be passed as tag metadata to the key vault.
+
+    :param connection_auth: A dict with subscription and authentication parameters to be used in connecting to the
+        Azure Resource Manager API.
+
+    Example usage:
+
+    .. code-block:: yaml
+
+        Ensure log analytics workspace exists:
+            azurerm.log_analytics.workspace.present:
+                - name: my_vault
+                - resource_group: my_rg
+                - location: my_location
+                - tags:
+                    contact_name: Elmer Fudd Gantry
+                - connection_auth: {{ profile }}
+
+    '''
+    ret = {
+        'name': name,
+        'result': False,
+        'comment': '',
+        'changes': {}
+    }
+
+    if not isinstance(connection_auth, dict):
+        ret['comment'] = 'Connection information must be specified via connection_auth dictionary!'
+        return ret
+
+    workspace = await hub.exec.azurerm.log_analytics.workspace.get(
+        name,
+        resource_group,
+        azurearm_log_level='info',
+        **connection_auth
+    )
+
+    if 'error' not in workspace:
+        if tags:
+            tag_changes = await hub.exec.utils.dictdiffer.deep_diff(workspace.get('tags', {}), tags)
+            if tag_changes:
+                ret['changes']['tags'] = tag_changes
+
+        if sku:
+            if sku.lower() != workspace.get('sku').get('name').lower():
+                ret['changes']['sku'] = {
+                    'old': workspace.get('sku').get('name'),
+                    'new': sku
+                }
+
+        if retention is not None:
+            if retention != workspace.get('retention_in_days'):
+                ret['changes']['retention_in_days'] = {
+                    'old': workspace.get('retention_in_days'),
+                    'new': retention
+                }
+
+        if customer_id:
+            if customer_id != workspace.get('customer_id'):
+                ret['changes']['customer_id'] = {
+                    'old': workspace.get('customer_id'),
+                    'new': customer_id
+                }
+
+        if etag:
+            if etag != workspace.get('e_tag'):
+                ret['changes']['e_tag'] = {
+                    'old': workspace.get('e_tag'),
+                    'new': etag
+                }
+
+        if not ret['changes']:
+            ret['result'] = True
+            ret['comment'] = 'Log Analytics Workspace {0} is already present.'.format(name)
+            return ret
+
+        if ctx['test']:
+            ret['result'] = None
+            ret['comment'] = 'Log Analytics Workspace {0} would be updated.'.format(name)
+            return ret
+
+    else:
+        ret['changes'] = {
+            'old': {},
+            'new': {
+                'name': name,
+                'resource_group': resource_group,
+                'location': location,
+            }
+        }
+
+        if tags:
+            ret['changes']['new']['tags'] = tags
+        if sku:
+            ret['changes']['new']['sku'] = {'name': sku}
+        if customer_id:
+            ret['changes']['new']['customer_id'] = customer_id
+        if retention is not None:
+            ret['changes']['new']['retention_in_days'] = retention
+        if etag:
+            ret['changes']['new']['e_tag'] = etag
+
+    if ctx['test']:
+        ret['comment'] = 'Log Analytics Workspace {0} would be created.'.format(name)
+        ret['result'] = None
+        return ret
+
+    workspace_kwargs = kwargs.copy()
+    workspace_kwargs.update(connection_auth)
+
+    workspace = await hub.exec.azurerm.log_analytics.workspace.create_or_update(
+        name=name,
+        resource_group=resource_group,
+        location=location,
+        sku=sku,
+        retention=retention,
+        etag=etag,
+        customer_id=customer_id,
+        tags=tags,
+        **workspace_kwargs
+    )
+
+    if 'error' not in workspace:
+        ret['result'] = True
+        ret['comment'] = 'Log Analytics Workspace {0} has been created.'.format(name)
+        return ret
+
+    ret['comment'] = 'Failed to create Log Analytics Workspace {0}! ({1})'.format(name, workspace.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
+    return ret
+
+
+async def absent(hub, ctx, name, resource_group, connection_auth=None):
+    '''
+    .. versionadded:: 1.0.0
+
+    Ensure a specified Log Analytics Workspace does not exist.
+
+    :param name: The name of the workspace.
+
+    :param resource_group: The resource group name of the workspace.
+
+    :param connection_auth: A dict with subscription and authentication parameters to be used in connecting to the
+        Azure Resource Manager API.
+
+    Example usage:
+
+    .. code-block:: yaml
+
+        Ensure log analytics workspace is absent:
+            azurerm.log_analytics.workspace.absent:
+                - name: my_vault
+                - resource_group: my_rg
+                - connection_auth: {{ profile }}
+
+    '''
+    ret = {
+        'name': name,
+        'result': False,
+        'comment': '',
+        'changes': {}
+    }
+
+    if not isinstance(connection_auth, dict):
+        ret['comment'] = 'Connection information must be specified via connection_auth dictionary!'
+        return ret
+
+    workspace = await hub.exec.azurerm.log_analytics.workspace.get(
+        name,
+        resource_group,
+        azurearm_log_level='info',
+        **connection_auth
+    )
+
+    if 'error' in workspace:
+        ret['result'] = True
+        ret['comment'] = 'Log Analytics Workspace {0} was not found.'.format(name)
+        return ret
+
+    elif ctx['test']:
+        ret['comment'] = 'Log Analytics Workspace {0} would be deleted.'.format(name)
+        ret['result'] = None
+        ret['changes'] = {
+            'old': workspace,
+            'new': {},
+        }
+        return ret
+
+    deleted = await hub.exec.azurerm.log_analytics.workspace.delete(
+        name,
+        resource_group,
+        **connection_auth
+    )
+
+    if deleted:
+        ret['result'] = True
+        ret['comment'] = 'Log Analytics Workspace {0} has been deleted.'.format(name)
+        ret['changes'] = {
+            'old': workspace,
+            'new': {}
+        }
+        return ret
+
+    ret['comment'] = 'Failed to delete Log Analytics Workspace {0}!'.format(name)
+    return ret

--- a/idem_provider_azurerm/states/azurerm/log_analytics/workspace.py
+++ b/idem_provider_azurerm/states/azurerm/log_analytics/workspace.py
@@ -2,7 +2,7 @@
 '''
 Azure Resource Manager (ARM) Log Analytics Workspace State Module
 
-.. versionadded:: 1.0.0
+.. versionadded:: VERSION
 
 :maintainer: <devops@eitr.tech>
 :maturity: new
@@ -78,7 +78,7 @@ TREQ = {
 }
 
 
-async def present(hub, ctx, name, resource_group, location, sku=None, retention=None, customer_id=None, etag=None,
+async def present(hub, ctx, name, resource_group, location, sku=None, retention=None, customer_id=None,
                   tags=None, connection_auth=None, **kwargs):
     '''
     .. versionadded:: VERSION
@@ -99,8 +99,6 @@ async def present(hub, ctx, name, resource_group, location, sku=None, retention=
 
     :param customer_id: The ID associated with the workspace. Setting this value at creation time allows the workspace
         being created to be linked to an existing workspace.
-
-    :param etag: The ETag of the workspace.
 
     :param tags: A dictionary of strings can be passed as tag metadata to the key vault.
 
@@ -166,11 +164,11 @@ async def present(hub, ctx, name, resource_group, location, sku=None, retention=
                     'new': customer_id
                 }
 
-        if etag:
-            if etag != workspace.get('e_tag'):
+        if kwargs.get('etag'):
+            if kwargs.get('etag') != workspace.get('e_tag'):
                 ret['changes']['e_tag'] = {
                     'old': workspace.get('e_tag'),
-                    'new': etag
+                    'new': kwargs.get('etag')
                 }
 
         if not ret['changes']:
@@ -201,8 +199,8 @@ async def present(hub, ctx, name, resource_group, location, sku=None, retention=
             ret['changes']['new']['customer_id'] = customer_id
         if retention is not None:
             ret['changes']['new']['retention_in_days'] = retention
-        if etag:
-            ret['changes']['new']['e_tag'] = etag
+        if kwargs.get('etag'):
+            ret['changes']['new']['e_tag'] = kwargs.get('etag')
 
     if ctx['test']:
         ret['comment'] = 'Log Analytics Workspace {0} would be created.'.format(name)
@@ -218,7 +216,6 @@ async def present(hub, ctx, name, resource_group, location, sku=None, retention=
         location=location,
         sku=sku,
         retention=retention,
-        etag=etag,
         customer_id=customer_id,
         tags=tags,
         **workspace_kwargs
@@ -237,7 +234,7 @@ async def present(hub, ctx, name, resource_group, location, sku=None, retention=
 
 async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
-    .. versionadded:: 1.0.0
+    .. versionadded:: VERSION
 
     Ensure a specified Log Analytics Workspace does not exist.
 
@@ -291,13 +288,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    workspace_kwargs = kwargs.copy()
-    workspace_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.log_analytics.workspace.delete(
         name,
         resource_group,
-        **workspace_kwargs
+        **connection_auth
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/log_analytics/workspace.py
+++ b/idem_provider_azurerm/states/azurerm/log_analytics/workspace.py
@@ -235,7 +235,7 @@ async def present(hub, ctx, name, resource_group, location, sku=None, retention=
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -291,10 +291,13 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
+    workspace_kwargs = kwargs.copy()
+    workspace_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.log_analytics.workspace.delete(
         name,
         resource_group,
-        **connection_auth
+        **workspace_kwargs
     )
 
     if deleted:


### PR DESCRIPTION
This PR provides a state and the required execution modules for Log Analytics Workspaces. It adds the LogAnalyticsManagementClient as an option for the get_client function in the azurerm.py util file. Additionally, a couple of extra execution modules were thrown in as well. At a later point the remaining execution modules can be added to the provider using the operations found [HERE](https://docs.microsoft.com/en-us/python/api/azure-mgmt-loganalytics/azure.mgmt.loganalytics.operations.workspaces_operations.workspacesoperations?view=azure-python).

NOTE: I added in the etag parameter to the present state module and create_or_update exec module; however, I am unsure if it is truly necessary or not. Please let me know your thoughts on that.