### PR TITLE
Key Vault Access Policies Fix

### DIFF
--- a/idem_provider_azurerm/exec/azurerm/keyvault/vault.py
+++ b/idem_provider_azurerm/exec/azurerm/keyvault/vault.py
@@ -49,11 +49,6 @@ Azure Resource Manager (ARM) Key Vault Execution Module
 from __future__ import absolute_import
 import logging
 
-try:
-    from six.moves import range as six_range
-except ImportError:
-    six_range = range
-
 # Azure libs
 HAS_LIBS = False
 try:
@@ -99,8 +94,8 @@ async def check_name_availability(hub, name, **kwargs):
 
 
 async def create_or_update(hub, name, resource_group, location, tenant_id, sku, access_policies=None, vault_uri=None,
-                           create_mode=None, enable_soft_delete=None, enable_purge_protection=None, 
-                           enabled_for_deployment=None, enabled_for_disk_encryption=None, 
+                           create_mode=None, enable_soft_delete=None, enable_purge_protection=None,
+                           enabled_for_deployment=None, enabled_for_disk_encryption=None,
                            enabled_for_template_deployment=None, **kwargs):
     '''
     .. versionadded:: 1.0.0

--- a/idem_provider_azurerm/states/azurerm/keyvault/vault.py
+++ b/idem_provider_azurerm/states/azurerm/keyvault/vault.py
@@ -182,7 +182,7 @@ async def present(hub, ctx, name, resource_group, location, tenant_id, sku, acce
                 - tags:
                     contact_name: Elmer Fudd Gantry
                 - connection_auth: {{ profile }}
-    
+
     '''
     ret = {
         'name': name,
@@ -206,19 +206,54 @@ async def present(hub, ctx, name, resource_group, location, tenant_id, sku, acce
         tag_changes = await hub.exec.utils.dictdiffer.deep_diff(vault.get('tags', {}), tags or {})
         if tag_changes:
             ret['changes']['tags'] = tag_changes
-    
+
         # Checks for changes in the account_policies parameter
         if len(access_policies or []) == len(vault.get('properties').get('access_policies', [])):
             new_policies_sorted = sorted(access_policies or [], key=itemgetter('object_id'))
             old_policies_sorted = sorted(vault.get('properties').get('access_policies', []), key=itemgetter('object_id'))
-            for index, policy in enumerate(new_policies_sorted):
-                changes = await hub.exec.utils.dictdiffer.deep_diff(old_policies_sorted[index], policy)
-                if changes:
-                    ret['changes']['access_policies'] = {
-                        'old': vault.get('properties').get('access_policies', []),
-                        'new': access_policies or []
-                    }
+            changed = False
+
+            for index, new_policy in enumerate(new_policies_sorted):
+                old_policy = old_policies_sorted[index]
+
+                # Checks for changes with the tenant_id key
+                if (old_policy.get('tenant_id') != new_policy.get('tenant_id')):
+                    changed = True
                     break
+
+                # Checks for changes with the object_id key
+                if (old_policy.get('object_id') != new_policy.get('object_id')):
+                    changed = True
+                    break
+
+                # Checks for changes within the permissions key
+                if new_policy['permissions'].get('keys') is not None:
+                    new_keys = sorted(new_policy['permissions'].get('keys'))
+                    old_keys = sorted(old_policy['permissions'].get('keys', []))
+                    if new_keys != old_keys:
+                        changed = True
+                        break
+
+                if new_policy['permissions'].get('secrets') is not None:
+                    new_secrets = sorted(new_policy['permissions'].get('secrets'))
+                    old_secrets = sorted(old_policy['permissions'].get('secrets', []))
+                    if new_secrets != old_secrets:
+                        changed = True
+                        break
+
+                if new_policy['permissions'].get('certificates') is not None:
+                    new_certificates = sorted(new_policy['permissions'].get('certificates'))
+                    old_certificates = sorted(old_policy['permissions'].get('certificates', []))
+                    if new_certificates != old_certificates:
+                        changed = True
+                        break
+
+            if changed:
+                ret['changes']['access_policies'] = {
+                    'old': vault.get('properties').get('access_policies', []),
+                    'new': access_policies
+                }
+
         else:
             ret['changes']['access_policies'] = {
                 'old': vault.get('properties').get('access_policies', []),
@@ -229,7 +264,7 @@ async def present(hub, ctx, name, resource_group, location, tenant_id, sku, acce
             ret['changes']['sku'] = {
                 'old': vault.get('properties').get('sku').get('name'),
                 'new': sku
-            } 
+            }
 
         if enabled_for_deployment is not None:
             if enabled_for_deployment != vault.get('properties').get('enabled_for_deployment'):
@@ -301,7 +336,7 @@ async def present(hub, ctx, name, resource_group, location, tenant_id, sku, acce
         if enabled_for_template_deployment is not None:
             ret['changes']['new']['enabled_for_template_deployment'] = enabled_for_template_deployment
         if enable_soft_delete is not None:
-            ret['changes']['new']['enable_soft_delete'] = enable_soft_delete 
+            ret['changes']['new']['enable_soft_delete'] = enable_soft_delete
         if create_mode:
             ret['changes']['new']['create_mode'] = create_mode
         if enable_purge_protection is not None:


### PR DESCRIPTION
This PR fixes the key vault state module's ability to check if there have been changes to the access policies of a key vault. This issue was reported in #17. Additionally, I removed an unnecessary import statement from the exec module that I had noticed.