### PR TITLE
Absent State Module Kwargs

### DIFF
--- a/idem_provider_azurerm/states/azurerm/compute/availability_set.py
+++ b/idem_provider_azurerm/states/azurerm/compute/availability_set.py
@@ -83,7 +83,6 @@ Azure Resource Manager (ARM) Compute Availability Set State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -99,8 +98,8 @@ TREQ = {
 }
 
 
-async def present(hub, ctx, name, resource_group, tags=None, platform_update_domain_count=None, platform_fault_domain_count=None,
-            virtual_machines=None, sku=None, connection_auth=None, **kwargs):
+async def present(hub, ctx, name, resource_group, tags=None, platform_update_domain_count=None,
+                  platform_fault_domain_count=None, virtual_machines=None, sku=None, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -257,10 +256,12 @@ async def present(hub, ctx, name, resource_group, tags=None, platform_update_dom
         return ret
 
     ret['comment'] = 'Failed to create availability set {0}! ({1})'.format(name, aset.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -275,6 +276,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -308,7 +310,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.compute.availability_set.delete(name, resource_group, **connection_auth)
+    aset_kwargs = kwargs.copy()
+    aset_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.compute.availability_set.delete(name, resource_group, **aset_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/compute/availability_set.py
+++ b/idem_provider_azurerm/states/azurerm/compute/availability_set.py
@@ -310,10 +310,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    aset_kwargs = kwargs.copy()
-    aset_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.compute.availability_set.delete(name, resource_group, **aset_kwargs)
+    deleted = await hub.exec.azurerm.compute.availability_set.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/compute/virtual_machine.py
+++ b/idem_provider_azurerm/states/azurerm/compute/virtual_machine.py
@@ -267,10 +267,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    vm_kwargs = kwargs.copy()
-    vm_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.compute.virtual_machine.delete(name, resource_group, **vm_kwargs)
+    deleted = await hub.exec.azurerm.compute.virtual_machine.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/compute/virtual_machine.py
+++ b/idem_provider_azurerm/states/azurerm/compute/virtual_machine.py
@@ -85,7 +85,6 @@ Azure Resource Manager (ARM) Compute Virtual Machine State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -214,6 +213,8 @@ async def present(hub, ctx, name, resource_group, tags=None, connection_auth=Non
         return ret
 
     ret['comment'] = 'Failed to create virtual machine {0}! ({1})'.format(name, vm.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
@@ -232,6 +233,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,

--- a/idem_provider_azurerm/states/azurerm/dns/record_set.py
+++ b/idem_provider_azurerm/states/azurerm/dns/record_set.py
@@ -420,10 +420,7 @@ async def absent(hub, ctx, name, zone_name, resource_group, connection_auth=None
         }
         return ret
 
-    rec_set_kwargs = kwargs.copy()
-    rec_set_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.dns.record_set.delete(name, zone_name, resource_group, **rec_set_kwargs)
+    deleted = await hub.exec.azurerm.dns.record_set.delete(name, zone_name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/dns/record_set.py
+++ b/idem_provider_azurerm/states/azurerm/dns/record_set.py
@@ -87,7 +87,6 @@ parameters are sensitive, it's recommended to pass them to the states via pillar
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -363,10 +362,12 @@ async def present(hub, ctx, name, zone_name, resource_group, record_type, if_mat
         return ret
 
     ret['comment'] = 'Failed to create record set {0}! ({1})'.format(name, rec_set.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, zone_name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, zone_name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -384,6 +385,7 @@ async def absent(hub, ctx, name, zone_name, resource_group, connection_auth=None
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -418,7 +420,10 @@ async def absent(hub, ctx, name, zone_name, resource_group, connection_auth=None
         }
         return ret
 
-    deleted = await hub.exec.azurerm.dns.record_set.delete(name, zone_name, resource_group, **connection_auth)
+    rec_set_kwargs = kwargs.copy()
+    rec_set_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.dns.record_set.delete(name, zone_name, resource_group, **rec_set_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/dns/zone.py
+++ b/idem_provider_azurerm/states/azurerm/dns/zone.py
@@ -314,10 +314,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    zone_kwargs = kwargs.copy()
-    zone_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.dns.zone.delete(name, resource_group, **zone_kwargs)
+    deleted = await hub.exec.azurerm.dns.zone.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/dns/zone.py
+++ b/idem_provider_azurerm/states/azurerm/dns/zone.py
@@ -80,7 +80,6 @@ parameters are sensitive, it's recommended to pass them to the states via pillar
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -261,10 +260,12 @@ async def present(hub, ctx, name, resource_group, etag=None, if_match=None, if_n
         return ret
 
     ret['comment'] = 'Failed to create DNS zone {0}! ({1})'.format(name, zone.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -279,6 +280,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -312,7 +314,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.dns.zone.delete(name, resource_group, **connection_auth)
+    zone_kwargs = kwargs.copy()
+    zone_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.dns.zone.delete(name, resource_group, **zone_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/keyvault/key.py
+++ b/idem_provider_azurerm/states/azurerm/keyvault/key.py
@@ -298,13 +298,10 @@ async def absent(hub, ctx, name, vault_url, connection_auth=None, **kwargs):
         }
         return ret
 
-    key_kwargs = kwargs.copy()
-    key_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.keyvault.key.begin_delete_key(
         name=name,
         vault_url=vault_url,
-        **key_kwargs
+        **connection_auth
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/keyvault/key.py
+++ b/idem_provider_azurerm/states/azurerm/keyvault/key.py
@@ -242,7 +242,7 @@ async def present(hub, ctx, name, key_type, vault_url, key_ops=None, enabled=Non
     return ret
 
 
-async def absent(hub, ctx, name, vault_url, connection_auth=None):
+async def absent(hub, ctx, name, vault_url, connection_auth=None, **kwargs):
     '''
     .. versionadded:: VERSION
 
@@ -298,10 +298,13 @@ async def absent(hub, ctx, name, vault_url, connection_auth=None):
         }
         return ret
 
+    key_kwargs = kwargs.copy()
+    key_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.keyvault.key.begin_delete_key(
         name=name,
         vault_url=vault_url,
-        **connection_auth
+        **key_kwargs
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/keyvault/vault.py
+++ b/idem_provider_azurerm/states/azurerm/keyvault/vault.py
@@ -434,13 +434,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    vault_kwargs = kwargs.copy()
-    vault_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.keyvault.vault.delete(
         name,
         resource_group,
-        **vault_kwargs
+        **connection_auth
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/keyvault/vault.py
+++ b/idem_provider_azurerm/states/azurerm/keyvault/vault.py
@@ -378,7 +378,7 @@ async def present(hub, ctx, name, resource_group, location, tenant_id, sku, acce
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -434,10 +434,13 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
+    vault_kwargs = kwargs.copy()
+    vault_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.keyvault.vault.delete(
         name,
         resource_group,
-        **connection_auth
+        **vault_kwargs
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/monitor/diagnostic_setting.py
+++ b/idem_provider_azurerm/states/azurerm/monitor/diagnostic_setting.py
@@ -300,7 +300,7 @@ async def present(hub, ctx, name, resource_uri, metrics, logs, workspace_id=None
     return ret
 
 
-async def absent(hub, ctx, name, resource_uri, connection_auth=None):
+async def absent(hub, ctx, name, resource_uri, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -356,10 +356,13 @@ async def absent(hub, ctx, name, resource_uri, connection_auth=None):
         }
         return ret
 
+    setting_kwargs = kwargs.copy()
+    setting_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.monitor.diagnostic_setting.delete(
         name,
         resource_uri,
-        **connection_auth
+        **setting_kwargs
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/monitor/diagnostic_setting.py
+++ b/idem_provider_azurerm/states/azurerm/monitor/diagnostic_setting.py
@@ -356,13 +356,10 @@ async def absent(hub, ctx, name, resource_uri, connection_auth=None, **kwargs):
         }
         return ret
 
-    setting_kwargs = kwargs.copy()
-    setting_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.monitor.diagnostic_setting.delete(
         name,
         resource_uri,
-        **setting_kwargs
+        **connection_auth
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/network/load_balancer.py
+++ b/idem_provider_azurerm/states/azurerm/network/load_balancer.py
@@ -511,10 +511,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    lb_kwargs = kwargs.copy()
-    lb_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.network.load_balancer.delete(name, resource_group, **lb_kwargs)
+    deleted = await hub.exec.azurerm.network.load_balancer.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/network/load_balancer.py
+++ b/idem_provider_azurerm/states/azurerm/network/load_balancer.py
@@ -85,7 +85,6 @@ Azure Resource Manager (ARM) Network Load Balancer State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -458,10 +457,12 @@ async def present(hub, ctx, name, resource_group, sku=None, frontend_ip_configur
         return ret
 
     ret['comment'] = 'Failed to create load balancer {0}! ({1})'.format(name, load_bal.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -476,6 +477,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -509,7 +511,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.network.load_balancer.delete(name, resource_group, **connection_auth)
+    lb_kwargs = kwargs.copy()
+    lb_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.network.load_balancer.delete(name, resource_group, **lb_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/network/local_network_gateway.py
+++ b/idem_provider_azurerm/states/azurerm/network/local_network_gateway.py
@@ -321,13 +321,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    gateway_kwargs = kwargs.copy()
-    gateway_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.network.local_network_gateway.delete(
         name,
         resource_group,
-        **gateway_kwargs
+        **connection_auth
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/network/local_network_gateway.py
+++ b/idem_provider_azurerm/states/azurerm/network/local_network_gateway.py
@@ -85,7 +85,6 @@ Azure Resource Manager (ARM) Local Network Gateway State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -102,8 +101,8 @@ TREQ = {
 }
 
 
-async def present(hub, ctx, name, resource_group, gateway_ip_address, bgp_settings=None, address_prefixes=None, tags=None,
-            connection_auth=None, **kwargs):
+async def present(hub, ctx, name, resource_group, gateway_ip_address, bgp_settings=None, address_prefixes=None,
+                  tags=None, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -259,10 +258,12 @@ async def present(hub, ctx, name, resource_group, gateway_ip_address, bgp_settin
         return ret
 
     ret['comment'] = 'Failed to create local network gateway {0}! ({1})'.format(name, gateway.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -320,10 +321,13 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
+    gateway_kwargs = kwargs.copy()
+    gateway_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.network.local_network_gateway.delete(
         name,
         resource_group,
-        **connection_auth
+        **gateway_kwargs
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/network/network_interface.py
+++ b/idem_provider_azurerm/states/azurerm/network/network_interface.py
@@ -85,7 +85,6 @@ Azure Resource Manager (ARM) Network Interface State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -105,9 +104,9 @@ TREQ = {
 }
 
 
-async def present(hub, ctx, name, ip_configurations, subnet, virtual_network, resource_group, tags=None, virtual_machine=None,
-            network_security_group=None, dns_settings=None, mac_address=None, primary=None,
-            enable_accelerated_networking=None, enable_ip_forwarding=None, connection_auth=None, **kwargs):
+async def present(hub, ctx, name, ip_configurations, subnet, virtual_network, resource_group, tags=None,
+                  virtual_machine=None, network_security_group=None, dns_settings=None, mac_address=None, primary=None,
+                  enable_accelerated_networking=None, enable_ip_forwarding=None, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -361,7 +360,7 @@ async def present(hub, ctx, name, ip_configurations, subnet, virtual_network, re
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -376,6 +375,17 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
+    Example usage:
+
+    .. code-block:: yaml
+
+        Ensure network interface absent:
+            azurerm.network.network_interface.absent:
+                - name: iface1
+                - resource_group: group1
+                - connection_auth: {{ profile }}
+
     '''
     ret = {
         'name': name,
@@ -409,7 +419,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.network.network_interface.delete(name, resource_group, **connection_auth)
+    iface_kwargs = kwargs.copy()
+    iface_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.network.network_interface.delete(name, resource_group, **iface_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/network/network_interface.py
+++ b/idem_provider_azurerm/states/azurerm/network/network_interface.py
@@ -357,6 +357,8 @@ async def present(hub, ctx, name, ip_configurations, subnet, virtual_network, re
         return ret
 
     ret['comment'] = 'Failed to create network interface {0}! ({1})'.format(name, iface.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
@@ -419,10 +421,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    iface_kwargs = kwargs.copy()
-    iface_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.network.network_interface.delete(name, resource_group, **iface_kwargs)
+    deleted = await hub.exec.azurerm.network.network_interface.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/network/network_security_group.py
+++ b/idem_provider_azurerm/states/azurerm/network/network_security_group.py
@@ -313,10 +313,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    nsg_kwargs = kwargs.copy()
-    nsg_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.network.network_security_group.delete(name, resource_group, **nsg_kwargs)
+    deleted = await hub.exec.azurerm.network.network_security_group.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True
@@ -715,14 +712,11 @@ async def security_rule_absent(hub, ctx, name, security_group, resource_group, c
         }
         return ret
 
-    rule_kwargs = kwargs.copy()
-    rule_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.network.network_security_group.security_rule_delete(
         name,
         security_group,
         resource_group,
-        **rule_kwargs
+        **connection_auth
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/network/network_security_group.py
+++ b/idem_provider_azurerm/states/azurerm/network/network_security_group.py
@@ -85,7 +85,6 @@ Azure Resource Manager (ARM) Network Security Group State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -250,10 +249,12 @@ async def present(hub, ctx, name, resource_group, tags=None, security_rules=None
         return ret
 
     ret['comment'] = 'Failed to create network security group {0}! ({1})'.format(name, nsg.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -268,6 +269,17 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
+    Example usage:
+
+    .. code-block:: yaml
+
+        Ensure nsg is absent:
+            azurerm.network.network_security_group.absent:
+                - name: nsg1
+                - resource_group: group1
+                - connection_auth: {{ profile }}
+
     '''
     ret = {
         'name': name,
@@ -301,7 +313,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.network.network_security_group.delete(name, resource_group, **connection_auth)
+    nsg_kwargs = kwargs.copy()
+    nsg_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.network.network_security_group.delete(name, resource_group, **nsg_kwargs)
 
     if deleted:
         ret['result'] = True
@@ -631,10 +646,12 @@ async def security_rule_present(hub, ctx, name, access, direction, priority, pro
         return ret
 
     ret['comment'] = 'Failed to create security rule {0}! ({1})'.format(name, rule.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def security_rule_absent(hub, ctx, name, security_group, resource_group, connection_auth=None):
+async def security_rule_absent(hub, ctx, name, security_group, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -652,6 +669,18 @@ async def security_rule_absent(hub, ctx, name, security_group, resource_group, c
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
+    Example usage:
+
+    .. code-block:: yaml
+
+        Ensure security rule absent:
+            azurerm.network.network_security_group.security_rule_absent:
+                - name: nsg1_rule2
+                - security_group: nsg1
+                - resource_group: group1
+                - connection_auth: {{ profile }}
+
     '''
     ret = {
         'name': name,
@@ -686,11 +715,14 @@ async def security_rule_absent(hub, ctx, name, security_group, resource_group, c
         }
         return ret
 
+    rule_kwargs = kwargs.copy()
+    rule_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.network.network_security_group.security_rule_delete(
         name,
         security_group,
         resource_group,
-        **connection_auth
+        **rule_kwargs
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/network/public_ip_address.py
+++ b/idem_provider_azurerm/states/azurerm/network/public_ip_address.py
@@ -338,10 +338,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    pub_ip_kwargs = kwargs.copy()
-    pub_ip_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.network.public_ip_address.delete(name, resource_group, **pub_ip_kwargs)
+    deleted = await hub.exec.azurerm.network.public_ip_address.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/network/public_ip_address.py
+++ b/idem_provider_azurerm/states/azurerm/network/public_ip_address.py
@@ -85,7 +85,6 @@ Azure Resource Manager (ARM) Network Public IP Address State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -285,10 +284,12 @@ async def present(hub, ctx, name, resource_group, tags=None, sku=None, public_ip
         return ret
 
     ret['comment'] = 'Failed to create public IP address {0}! ({1})'.format(name, pub_ip.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -303,6 +304,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -336,7 +338,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.network.public_ip_address.delete(name, resource_group, **connection_auth)
+    pub_ip_kwargs = kwargs.copy()
+    pub_ip_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.network.public_ip_address.delete(name, resource_group, **pub_ip_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/network/route.py
+++ b/idem_provider_azurerm/states/azurerm/network/route.py
@@ -85,7 +85,6 @@ Azure Resource Manager (ARM) Network Route State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -246,10 +245,12 @@ async def table_present(hub, ctx, name, resource_group, tags=None, routes=None, 
         return ret
 
     ret['comment'] = 'Failed to create route table {0}! ({1})'.format(name, rt_tbl.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def table_absent(hub, ctx, name, resource_group, connection_auth=None):
+async def table_absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -264,6 +265,7 @@ async def table_absent(hub, ctx, name, resource_group, connection_auth=None):
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -297,7 +299,10 @@ async def table_absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.network.route.table_delete(name, resource_group, **connection_auth)
+    rt_tbl_kwargs = kwargs.copy()
+    rt_tbl_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.network.route.table_delete(name, resource_group, **rt_tbl_kwargs)
 
     if deleted:
         ret['result'] = True
@@ -442,10 +447,12 @@ async def present(hub, ctx, name, address_prefix, next_hop_type, route_table, re
         return ret
 
     ret['comment'] = 'Failed to create route {0}! ({1})'.format(name, route.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, route_table, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, route_table, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -463,6 +470,7 @@ async def absent(hub, ctx, name, route_table, resource_group, connection_auth=No
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -497,7 +505,10 @@ async def absent(hub, ctx, name, route_table, resource_group, connection_auth=No
         }
         return ret
 
-    deleted = await hub.exec.azurerm.network.route.delete(name, route_table, resource_group, **connection_auth)
+    route_kwargs = kwargs.copy()
+    route_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.network.route.delete(name, route_table, resource_group, **route_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/network/route.py
+++ b/idem_provider_azurerm/states/azurerm/network/route.py
@@ -299,10 +299,7 @@ async def table_absent(hub, ctx, name, resource_group, connection_auth=None, **k
         }
         return ret
 
-    rt_tbl_kwargs = kwargs.copy()
-    rt_tbl_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.network.route.table_delete(name, resource_group, **rt_tbl_kwargs)
+    deleted = await hub.exec.azurerm.network.route.table_delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True
@@ -505,10 +502,7 @@ async def absent(hub, ctx, name, route_table, resource_group, connection_auth=No
         }
         return ret
 
-    route_kwargs = kwargs.copy()
-    route_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.network.route.delete(name, route_table, resource_group, **route_kwargs)
+    deleted = await hub.exec.azurerm.network.route.delete(name, route_table, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/network/virtual_network.py
+++ b/idem_provider_azurerm/states/azurerm/network/virtual_network.py
@@ -307,10 +307,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    vnet_kwargs = kwargs.copy()
-    vnet_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.network.virtual_network.delete(name, resource_group, **vnet_kwargs)
+    deleted = await hub.exec.azurerm.network.virtual_network.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True
@@ -522,14 +519,11 @@ async def subnet_absent(hub, ctx, name, virtual_network, resource_group, connect
         }
         return ret
 
-    snet_kwargs = kwargs.copy()
-    snet_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.network.virtual_network.subnet_delete(
         name,
         virtual_network,
         resource_group,
-        **snet_kwargs
+        **connection_auth
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/network/virtual_network_gateway.py
+++ b/idem_provider_azurerm/states/azurerm/network/virtual_network_gateway.py
@@ -85,7 +85,6 @@ Azure Resource Manager (ARM) Virtual Network Gateway State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -451,7 +450,7 @@ async def connection_present(hub, ctx, name, resource_group, virtual_network_gat
     return ret
 
 
-async def connection_absent(hub, ctx, name, resource_group, connection_auth=None):
+async def connection_absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -510,13 +509,10 @@ async def connection_absent(hub, ctx, name, resource_group, connection_auth=None
         }
         return ret
 
-    connection_kwargs = kwargs.copy()
-    connection_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.network.virtual_network_gateway.connection_delete(
         name,
         resource_group,
-        **connection_kwargs
+        **connection_auth
     )
 
     if deleted:
@@ -863,13 +859,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    gateway_kwargs = kwargs.copy()
-    gateway_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.network.virtual_network_gateway.delete(
         name,
         resource_group,
-        **gateway_kwargs
+        **connection_auth
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/network/virtual_network_gateway.py
+++ b/idem_provider_azurerm/states/azurerm/network/virtual_network_gateway.py
@@ -243,6 +243,7 @@ async def connection_present(hub, ctx, name, resource_group, virtual_network_gat
                 - require:
                   - azurearm_resource: Ensure resource group exists
                   - azurearm_network: Ensure virtual network gateway exists
+
     '''
     ret = {
         'name': name,
@@ -445,6 +446,8 @@ async def connection_present(hub, ctx, name, resource_group, virtual_network_gat
         return ret
 
     ret['comment'] = 'Failed to create virtual network gateway connection {0}! ({1})'.format(name, con.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
@@ -473,6 +476,7 @@ async def connection_absent(hub, ctx, name, resource_group, connection_auth=None
                 - name: connection1
                 - resource_group: group1
                 - connection_auth: {{ profile }}
+
     '''
     ret = {
         'name': name,
@@ -506,10 +510,13 @@ async def connection_absent(hub, ctx, name, resource_group, connection_auth=None
         }
         return ret
 
+    connection_kwargs = kwargs.copy()
+    connection_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.network.virtual_network_gateway.connection_delete(
         name,
         resource_group,
-        **connection_auth
+        **connection_kwargs
     )
 
     if deleted:
@@ -643,6 +650,7 @@ async def present(hub, ctx, name, resource_group, virtual_network, ip_configurat
                 - require:
                   - azurearm_resource: Ensure resource group exists
                   - azurearm_network: Ensure virtual network gateway exists
+
     '''
     ret = {
         'name': name,
@@ -791,10 +799,12 @@ async def present(hub, ctx, name, resource_group, virtual_network, ip_configurat
         return ret
 
     ret['comment'] = 'Failed to create virtual network gateway {0}! ({1})'.format(name, gateway.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -819,6 +829,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
                 - name: gateway1
                 - resource_group: group1
                 - connection_auth: {{ profile }}
+
     '''
     ret = {
         'name': name,
@@ -852,10 +863,13 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
+    gateway_kwargs = kwargs.copy()
+    gateway_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.network.virtual_network_gateway.delete(
         name,
         resource_group,
-        **connection_auth
+        **gateway_kwargs
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/network/virtual_network_peering.py
+++ b/idem_provider_azurerm/states/azurerm/network/virtual_network_peering.py
@@ -85,7 +85,6 @@ Azure Resource Manager (ARM) Virtual Network Peering State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -297,10 +296,12 @@ async def present(hub, ctx, name, remote_virtual_network, virtual_network, resou
         return ret
 
     ret['comment'] = 'Failed to create peering object {0}! ({1})'.format(name, peering.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def absent(hub, ctx, name, virtual_network, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, virtual_network, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -318,6 +319,7 @@ async def absent(hub, ctx, name, virtual_network, resource_group, connection_aut
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -352,11 +354,14 @@ async def absent(hub, ctx, name, virtual_network, resource_group, connection_aut
         }
         return ret
 
+    remote_peering_kwargs = remote_peering.copy()
+    remote_peering_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.network.virtual_network_peering.delete(
         name,
         virtual_network,
         resource_group,
-        **connection_auth
+        **remote_peering_kwargs
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/network/virtual_network_peering.py
+++ b/idem_provider_azurerm/states/azurerm/network/virtual_network_peering.py
@@ -354,14 +354,11 @@ async def absent(hub, ctx, name, virtual_network, resource_group, connection_aut
         }
         return ret
 
-    remote_peering_kwargs = remote_peering.copy()
-    remote_peering_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.network.virtual_network_peering.delete(
         name,
         virtual_network,
         resource_group,
-        **remote_peering_kwargs
+        **connection_auth
     )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/redis/operations.py
+++ b/idem_provider_azurerm/states/azurerm/redis/operations.py
@@ -295,7 +295,7 @@ async def present(hub, ctx, name, resource_group, location, sku, redis_configura
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -350,7 +350,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.redis.operations.delete(name, resource_group, **connection_auth)
+    cache_kwargs = kwargs.copy()
+    cache_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.redis.operations.delete(name, resource_group, **cache_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/redis/operations.py
+++ b/idem_provider_azurerm/states/azurerm/redis/operations.py
@@ -350,10 +350,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    cache_kwargs = kwargs.copy()
-    cache_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.redis.operations.delete(name, resource_group, **cache_kwargs)
+    deleted = await hub.exec.azurerm.redis.operations.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/resource/group.py
+++ b/idem_provider_azurerm/states/azurerm/resource/group.py
@@ -244,11 +244,7 @@ async def absent(hub, ctx, name, connection_auth=None, **kwargs):
         return ret
 
     group = await hub.exec.azurerm.resource.group.get(name, **connection_auth)
-
-    group_kwargs = kwargs.copy()
-    group_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.resource.group.delete(name, **group_kwargs)
+    deleted = await hub.exec.azurerm.resource.group.delete(name, **connection_auth)
 
     if deleted:
         present = False

--- a/idem_provider_azurerm/states/azurerm/resource/management_lock.py
+++ b/idem_provider_azurerm/states/azurerm/resource/management_lock.py
@@ -207,7 +207,7 @@ async def present_by_scope(hub, ctx, name, scope, lock_level, notes=None, owners
     return ret
 
 
-async def absent_by_scope(hub, ctx, name, scope, connection_auth=None):
+async def absent_by_scope(hub, ctx, name, scope, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -267,10 +267,13 @@ async def absent_by_scope(hub, ctx, name, scope, connection_auth=None):
         }
         return ret
 
+    lock_kwargs = kwargs.copy()
+    lock_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.resource.management_lock.delete_by_scope(
         name,
         scope,
-        **connection_auth
+        **lock_kwargs
     )
 
     if deleted:
@@ -448,7 +451,7 @@ async def present_at_resource_level(hub, ctx, name, lock_level, resource_group, 
 
 
 async def absent_at_resource_level(hub, ctx, name, resource_group, resource, resource_type, resource_provider_namespace,
-                          parent_resource_path=None, connection_auth=None):
+                          parent_resource_path=None, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -520,6 +523,9 @@ async def absent_at_resource_level(hub, ctx, name, resource_group, resource, res
         }
         return ret
 
+    lock_kwargs = kwargs.copy()
+    lock_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.resource.management_lock.delete_at_resource_level(
         name,
         resource_group,
@@ -527,7 +533,7 @@ async def absent_at_resource_level(hub, ctx, name, resource_group, resource, res
         resource_type,
         resource_provider_namespace,
         parent_resource_path=parent_resource_path,
-        **connection_auth
+        **lock_kwargs
     )
 
     if deleted:
@@ -654,7 +660,7 @@ async def present(hub, ctx, name, lock_level, resource_group=None, notes=None, o
         }
 
         if resource_group:
-            ret['changes']['new']['resource_group'] = resource_group    
+            ret['changes']['new']['resource_group'] = resource_group
         if owners:
             ret['changes']['new']['owners'] = owners
         if notes:
@@ -697,7 +703,7 @@ async def present(hub, ctx, name, lock_level, resource_group=None, notes=None, o
     return ret
 
 
-async def absent(hub, ctx, name, resource_group=None, connection_auth=None):
+async def absent(hub, ctx, name, resource_group=None, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -762,16 +768,19 @@ async def absent(hub, ctx, name, resource_group=None, connection_auth=None):
         }
         return ret
 
+    lock_kwargs = kwargs.copy()
+    lock_kwargs.update(connection_auth)
+
     if resource_group:
         deleted = await hub.exec.azurerm.resource.management_lock.delete_at_resource_group_level(
             name,
             resource_group,
-            **connection_auth
+            **lock_kwargs
         )
     else:
         deleted = await hub.exec.azurerm.resource.management_lock.delete_at_subscription_level(
             name,
-            **connection_auth
+            **lock_kwargs
         )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/resource/management_lock.py
+++ b/idem_provider_azurerm/states/azurerm/resource/management_lock.py
@@ -267,13 +267,10 @@ async def absent_by_scope(hub, ctx, name, scope, connection_auth=None, **kwargs)
         }
         return ret
 
-    lock_kwargs = kwargs.copy()
-    lock_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.resource.management_lock.delete_by_scope(
         name,
         scope,
-        **lock_kwargs
+        **connection_auth
     )
 
     if deleted:
@@ -523,9 +520,6 @@ async def absent_at_resource_level(hub, ctx, name, resource_group, resource, res
         }
         return ret
 
-    lock_kwargs = kwargs.copy()
-    lock_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.resource.management_lock.delete_at_resource_level(
         name,
         resource_group,
@@ -533,7 +527,7 @@ async def absent_at_resource_level(hub, ctx, name, resource_group, resource, res
         resource_type,
         resource_provider_namespace,
         parent_resource_path=parent_resource_path,
-        **lock_kwargs
+        **connection_auth
     )
 
     if deleted:
@@ -768,19 +762,16 @@ async def absent(hub, ctx, name, resource_group=None, connection_auth=None, **kw
         }
         return ret
 
-    lock_kwargs = kwargs.copy()
-    lock_kwargs.update(connection_auth)
-
     if resource_group:
         deleted = await hub.exec.azurerm.resource.management_lock.delete_at_resource_group_level(
             name,
             resource_group,
-            **lock_kwargs
+            **connection_auth
         )
     else:
         deleted = await hub.exec.azurerm.resource.management_lock.delete_at_subscription_level(
             name,
-            **lock_kwargs
+            **connection_auth
         )
 
     if deleted:

--- a/idem_provider_azurerm/states/azurerm/resource/policy.py
+++ b/idem_provider_azurerm/states/azurerm/resource/policy.py
@@ -410,10 +410,7 @@ async def definition_absent(hub, name, connection_auth=None, **kwargs):
         }
         return ret
 
-    policy_kwargs = kwargs.copy()
-    policy_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.resource.policy.definition_delete(name, **policy_kwargs)
+    deleted = await hub.exec.azurerm.resource.policy.definition_delete(name, **connection_auth)
 
     if deleted:
         ret['result'] = True
@@ -633,10 +630,7 @@ async def assignment_absent(hub, ctx, name, scope, connection_auth=None, **kwarg
         }
         return ret
 
-    policy_kwargs = kwargs.copy()
-    policy_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.resource.policy.assignment_delete(name, scope, **policy_kwargs)
+    deleted = await hub.exec.azurerm.resource.policy.assignment_delete(name, scope, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/resource/policy.py
+++ b/idem_provider_azurerm/states/azurerm/resource/policy.py
@@ -79,7 +79,6 @@ Azure Resource Manager (ARM) Resource Policy State Module
                 - connection_auth: {{ profile }}
 
 '''
-
 # Import Python libs
 from __future__ import absolute_import
 import json
@@ -365,10 +364,12 @@ async def definition_present(hub, ctx, name, policy_rule=None, policy_type=None,
         return ret
 
     ret['comment'] = 'Failed to create policy definition {0}! ({1})'.format(name, policy.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def definition_absent(hub, name, connection_auth=None):
+async def definition_absent(hub, name, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -380,6 +381,7 @@ async def definition_absent(hub, name, connection_auth=None):
     :param connection_auth:
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -408,7 +410,10 @@ async def definition_absent(hub, name, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.resource.policy.definition_delete(name, **connection_auth)
+    policy_kwargs = kwargs.copy()
+    policy_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.resource.policy.definition_delete(name, **policy_kwargs)
 
     if deleted:
         ret['result'] = True
@@ -423,8 +428,8 @@ async def definition_absent(hub, name, connection_auth=None):
     return ret
 
 
-async def assignment_present(hub, ctx, name, scope, definition_name, display_name=None, description=None, assignment_type=None,
-                              parameters=None, connection_auth=None, **kwargs):
+async def assignment_present(hub, ctx, name, scope, definition_name, display_name=None, description=None,
+                             assignment_type=None, parameters=None, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -574,10 +579,12 @@ async def assignment_present(hub, ctx, name, scope, definition_name, display_nam
         return ret
 
     ret['comment'] = 'Failed to create policy assignment {0}! ({1})'.format(name, policy.get('error'))
+    if not ret['result']:
+        ret['changes'] = {}
     return ret
 
 
-async def assignment_absent(hub, ctx, name, scope, connection_auth=None):
+async def assignment_absent(hub, ctx, name, scope, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -592,6 +599,7 @@ async def assignment_absent(hub, ctx, name, scope, connection_auth=None):
     connection_auth
         A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
+
     '''
     ret = {
         'name': name,
@@ -625,7 +633,10 @@ async def assignment_absent(hub, ctx, name, scope, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.resource.policy.assignment_delete(name, scope, **connection_auth)
+    policy_kwargs = kwargs.copy()
+    policy_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.resource.policy.assignment_delete(name, scope, **policy_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/storage/account.py
+++ b/idem_provider_azurerm/states/azurerm/storage/account.py
@@ -284,7 +284,7 @@ async def present(hub, ctx, name, resource_group, sku, kind, location, custom_do
     return ret
 
 
-async def absent(hub, ctx, name, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -338,7 +338,10 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.storage.account.delete(name, resource_group, **connection_auth)
+    account_kwargs = kwargs.copy()
+    account_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.storage.account.delete(name, resource_group, **account_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/storage/account.py
+++ b/idem_provider_azurerm/states/azurerm/storage/account.py
@@ -338,10 +338,7 @@ async def absent(hub, ctx, name, resource_group, connection_auth=None, **kwargs)
         }
         return ret
 
-    account_kwargs = kwargs.copy()
-    account_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.storage.account.delete(name, resource_group, **account_kwargs)
+    deleted = await hub.exec.azurerm.storage.account.delete(name, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/storage/container.py
+++ b/idem_provider_azurerm/states/azurerm/storage/container.py
@@ -59,8 +59,8 @@ Azure Resource Manager (ARM) Blob Container State Module
                 client_id: ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF
                 secret: XXXXXXXXXXXXXXXXXXXXXXXX
                 cloud_environment: AZURE_PUBLIC_CLOUD
-'''
 
+'''
 # Python libs
 from __future__ import absolute_import
 import logging
@@ -353,7 +353,7 @@ async def immutability_policy_present(hub, ctx, name, account, resource_group,
     return ret
 
 
-async def absent(hub, ctx, name, account, resource_group, connection_auth=None):
+async def absent(hub, ctx, name, account, resource_group, connection_auth=None, **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -414,7 +414,10 @@ async def absent(hub, ctx, name, account, resource_group, connection_auth=None):
         }
         return ret
 
-    deleted = await hub.exec.azurerm.storage.container.delete(name, account, resource_group, **connection_auth)
+    container_kwargs = kwargs.copy()
+    container_kwargs.update(connection_auth)
+
+    deleted = await hub.exec.azurerm.storage.container.delete(name, account, resource_group, **container_kwargs)
 
     if deleted:
         ret['result'] = True
@@ -429,7 +432,8 @@ async def absent(hub, ctx, name, account, resource_group, connection_auth=None):
     return ret
 
 
-async def immutability_policy_absent(hub, ctx, name, account, resource_group, if_match=None, connection_auth=None):
+async def immutability_policy_absent(hub, ctx, name, account, resource_group, if_match=None, connection_auth=None,
+                                     **kwargs):
     '''
     .. versionadded:: 1.0.0
 
@@ -499,8 +503,11 @@ async def immutability_policy_absent(hub, ctx, name, account, resource_group, if
     if not if_match:
         if_match = policy.get('etag')
 
+    policy_kwargs = kwargs.copy()
+    policy_kwargs.update(connection_auth)
+
     deleted = await hub.exec.azurerm.storage.container.delete_immutability_policy(name, account, resource_group,
-                                                                                  if_match, **connection_auth)
+                                                                                  if_match, **policy_kwargs)
 
     if deleted:
         ret['result'] = True

--- a/idem_provider_azurerm/states/azurerm/storage/container.py
+++ b/idem_provider_azurerm/states/azurerm/storage/container.py
@@ -414,10 +414,7 @@ async def absent(hub, ctx, name, account, resource_group, connection_auth=None, 
         }
         return ret
 
-    container_kwargs = kwargs.copy()
-    container_kwargs.update(connection_auth)
-
-    deleted = await hub.exec.azurerm.storage.container.delete(name, account, resource_group, **container_kwargs)
+    deleted = await hub.exec.azurerm.storage.container.delete(name, account, resource_group, **connection_auth)
 
     if deleted:
         ret['result'] = True
@@ -503,11 +500,8 @@ async def immutability_policy_absent(hub, ctx, name, account, resource_group, if
     if not if_match:
         if_match = policy.get('etag')
 
-    policy_kwargs = kwargs.copy()
-    policy_kwargs.update(connection_auth)
-
     deleted = await hub.exec.azurerm.storage.container.delete_immutability_policy(name, account, resource_group,
-                                                                                  if_match, **policy_kwargs)
+                                                                                  if_match, **connection_auth)
 
     if deleted:
         ret['result'] = True


### PR DESCRIPTION
This PR addresses issue #4 and adds kwargs to every absent state module. As long as I was working within all the state modules, I linted some of them and added or removed an empty line in some areas for consistency with other files. Additionally, I added `if not ret['result']: ret['changes'] = {}` to any present state module that did not already have it. This prevents changes from being shown when the present state fails.

All open PRs were also adjusted to include kwargs for absent state modules.