### PR TITLE
PostgreSQL 3/3

### DIFF
--- a/idem_provider_azurerm/exec/azurerm/postgresql/location_based_performance_tier.py
+++ b/idem_provider_azurerm/exec/azurerm/postgresql/location_based_performance_tier.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+'''
+Azure Resource Manager (ARM) PostgreSQL Location Based Performance Tier Operations Execution Module
+
+.. versionadded:: VERSION
+
+:maintainer: <devops@eitr.tech>
+:maturity: new
+:depends:
+    * `azure <https://pypi.python.org/pypi/azure>`_ >= 4.0.0
+    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.23
+    * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 4.0.0
+    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 4.6.2
+    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 4.0.0
+    * `azure-mgmt-rdbms <https://pypi.org/project/azure-mgmt-rdbms/>`_ >= 1.9.0
+    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 2.2.0
+    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 2.0.0
+    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.35.0
+    * `azure-storage <https://pypi.python.org/pypi/azure-storage>`_ >= 0.36.0
+    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.1
+:platform: linux
+
+:configuration: This module requires Azure Resource Manager credentials to be passed as keyword arguments
+    to every function in order to work properly.
+
+    Required provider parameters:
+
+    if using username and password:
+      * ``subscription_id``
+      * ``username``
+      * ``password``
+
+    if using a service principal:
+      * ``subscription_id``
+      * ``tenant``
+      * ``client_id``
+      * ``secret``
+
+    Optional provider parameters:
+
+**cloud_environment**: Used to point the cloud driver to different API endpoints, such as Azure GovCloud.
+    Possible values:
+      * ``AZURE_PUBLIC_CLOUD`` (default)
+      * ``AZURE_CHINA_CLOUD``
+      * ``AZURE_US_GOV_CLOUD``
+      * ``AZURE_GERMAN_CLOUD``
+
+'''
+# Python libs
+from __future__ import absolute_import
+import logging
+
+# Azure libs
+HAS_LIBS = False
+try:
+    import azure.mgmt.rdbms.postgresql.models  # pylint: disable=unused-import
+    from msrestazure.azure_exceptions import CloudError
+    HAS_LIBS = True
+except ImportError:
+    pass
+
+__func_alias__ = {"list_": "list"}
+
+log = logging.getLogger(__name__)
+
+
+async def list_(hub, location, **kwargs):
+    '''
+    .. versionadded:: VERSION
+
+    List all the performance tiers at specified location in a given subscription.
+
+    :param location: The name of the location.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        azurerm.postgresql.location_based_performance_tier.list test_location
+
+    '''
+    result = {}
+    postconn = await hub.exec.utils.azurerm.get_client('postgresql', **kwargs)
+
+    try:
+        tiers = await hub.exec.utils.azurerm.paged_object_to_list(
+            postconn.location_based_performance_tier.list(
+                location_name=location
+            )
+        )
+
+        for tier in tiers:
+            result[tier['id']] = tier
+    except CloudError as exc:
+        await hub.exec.utils.azurerm.log_cloud_error('postgresql', str(exc), **kwargs)
+        result = {'error': str(exc)}
+
+    return result

--- a/idem_provider_azurerm/exec/azurerm/postgresql/replicas.py
+++ b/idem_provider_azurerm/exec/azurerm/postgresql/replicas.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+'''
+Azure Resource Manager (ARM) PostgreSQL Server Replicas Operations Execution Module
+
+.. versionadded:: VERSION
+
+:maintainer: <devops@eitr.tech>
+:maturity: new
+:depends:
+    * `azure <https://pypi.python.org/pypi/azure>`_ >= 4.0.0
+    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.23
+    * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 4.0.0
+    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 4.6.2
+    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 4.0.0
+    * `azure-mgmt-rdbms <https://pypi.org/project/azure-mgmt-rdbms/>`_ >= 1.9.0
+    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 2.2.0
+    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 2.0.0
+    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.35.0
+    * `azure-storage <https://pypi.python.org/pypi/azure-storage>`_ >= 0.36.0
+    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.1
+:platform: linux
+
+:configuration: This module requires Azure Resource Manager credentials to be passed as keyword arguments
+    to every function in order to work properly.
+
+    Required provider parameters:
+
+    if using username and password:
+      * ``subscription_id``
+      * ``username``
+      * ``password``
+
+    if using a service principal:
+      * ``subscription_id``
+      * ``tenant``
+      * ``client_id``
+      * ``secret``
+
+    Optional provider parameters:
+
+**cloud_environment**: Used to point the cloud driver to different API endpoints, such as Azure GovCloud.
+    Possible values:
+      * ``AZURE_PUBLIC_CLOUD`` (default)
+      * ``AZURE_CHINA_CLOUD``
+      * ``AZURE_US_GOV_CLOUD``
+      * ``AZURE_GERMAN_CLOUD``
+
+'''
+# Python libs
+from __future__ import absolute_import
+import logging
+
+# Azure libs
+HAS_LIBS = False
+try:
+    import azure.mgmt.rdbms.postgresql.models  # pylint: disable=unused-import
+    from msrestazure.azure_exceptions import CloudError
+    HAS_LIBS = True
+except ImportError:
+    pass
+
+log = logging.getLogger(__name__)
+
+
+async def list_by_server(hub, server_name, resource_group, **kwargs):
+    '''
+    .. versionadded:: VERSION
+
+    List all the replicas for a given server.
+
+    :param server_name: The name of the server.
+
+    :param resource_group: The name of the resource group. The name is case insensitive.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        azurerm.postgresql.replicas.list_by_server test_server test_group
+
+    '''
+    result = {}
+    postconn = await hub.exec.utils.azurerm.get_client('postgresql', **kwargs)
+
+    try:
+        reps = await hub.exec.utils.azurerm.paged_object_to_list(
+            postconn.replicas.list_by_server(
+                server_name=server_name,
+                resource_group_name=resource_group
+            )
+        )
+
+        for rep in reps:
+            result[rep['name']] = rep
+    except CloudError as exc:
+        await hub.exec.utils.azurerm.log_cloud_error('postgresql', str(exc), **kwargs)
+        result = {'error': str(exc)}
+
+    return result

--- a/idem_provider_azurerm/exec/utils/azurerm.py
+++ b/idem_provider_azurerm/exec/utils/azurerm.py
@@ -12,6 +12,7 @@ Azure Resource Manager (ARM) Utilities
     * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 0.30.0rc6
     * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 0.33.0
     * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 0.30.0rc6
+    * `azure-mgmt-rdbms <https://pypi.org/project/azure-mgmt-rdbms/>`_ >= 1.9.0
     * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 0.30.0
     * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 0.30.0rc6
     * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.30.0rc6
@@ -141,6 +142,7 @@ async def get_client(hub, client_type, **kwargs):
                   'web': 'WebSiteManagement',
                   'keyvault': 'KeyVaultManagement',
                   'redis': 'RedisManagement',
+                  'postgresql': 'PostgreSQLManagement',
                   'loganalytics': 'LogAnalyticsManagement'}
 
     if client_type not in client_map:
@@ -155,6 +157,8 @@ async def get_client(hub, client_type, **kwargs):
         module_name = 'resource'
     elif client_type in ['managementlock']:
         module_name = 'resource.locks'
+    elif client_type in ['postgresql']:
+        module_name = 'rdbms.postgresql'
     else:
         module_name = client_type
 


### PR DESCRIPTION
Addresses issue #23  and adds execution modules for the following PostgreSQL operations:

[ReplicasOperations](https://docs.microsoft.com/en-us/python/api/azure-mgmt-rdbms/azure.mgmt.rdbms.postgresql.operations.replicasoperations?view=azure-python)
[LocationBasedPerformanceTierOperations](https://docs.microsoft.com/en-us/python/api/azure-mgmt-rdbms/azure.mgmt.rdbms.postgresql.operations.locationbasedperformancetieroperations?view=azure-python)

The execution and state modules for [PrivateLinkResourcesOperations](https://docs.microsoft.com/en-us/python/api/azure-mgmt-rdbms/azure.mgmt.rdbms.postgresql.operations.privatelinkresourcesoperations?view=azure-python) and [PrivateEndpointConnectionsOperations](https://docs.microsoft.com/en-us/python/api/azure-mgmt-rdbms/azure.mgmt.rdbms.postgresql.operations.privateendpointconnectionsoperations?view=azure-python) will need to be made in the future when a newer version of azure.mgmt.rdbms is released in the main azure package.